### PR TITLE
fix(dead): When main character dies the game ends, rather than whole party must die

### DIFF
--- a/zbpod/bp2scripts/ohbhub.baf
+++ b/zbpod/bp2scripts/ohbhub.baf
@@ -49,10 +49,10 @@ THEN
 END
 
 IF
-	NumInPartyAlive(0)
+  Dead(PC)
 THEN
-	RESPONSE #100
-		GameOver(103098)  // The party has been killed. You must restart the game.
+  RESPONSE #100
+    GameOver(17123) // The main character has died.
 END
 
 IF

--- a/zbpod/bp2scripts/zbtrain.baf
+++ b/zbpod/bp2scripts/zbtrain.baf
@@ -14,6 +14,13 @@ THEN
 END
 
 IF
+  Dead(PC)
+THEN
+  RESPONSE #100
+    GameOver(17123) // The main character has died.
+END
+
+IF
   Global("zb_train_spawn","global",1)
 THEN
   RESPONSE #100


### PR DESCRIPTION
Signed-off-by: dark0dave <dark0dave@mykolab.com>
